### PR TITLE
Adding/Testing sigint handler to write image to text file

### DIFF
--- a/pnt-lut.c
+++ b/pnt-lut.c
@@ -23,17 +23,22 @@
 #define PGM_H 300
 #define PGM_SIZE ((PGM_W) * (PGM_H)) + 15
 
+#define STR_EXPAND(tok) #tok
+#define STR(tok) STR_EXPAND(tok)
+
 #define TABLET_MAX_X 21600
 #define TABLET_MAX_Y 13500
 
 // flag to write image to file
 static volatile sig_atomic_t sig_rcvd = 0;
 
-int better_read(int fd, void *buf, int amount) {
+int better_read(int fd, void *buf, int amount)
+{
   int amt_read = 0;
   char *charbuf = (char *)buf;
 
-  while (amt_read < amount) {
+  while (amt_read < amount)
+  {
     int last_read = read(fd, charbuf + amt_read, amount - amt_read);
     amt_read += last_read;
   }
@@ -43,12 +48,14 @@ int better_read(int fd, void *buf, int amount) {
 
 void signal_handler(int signum)
 {
-  if (signum == 2) {
+  if (signum == 2)
+  {
     sig_rcvd = 1;
   }
 }
 
-int main(int ac, char *av[]) {
+int main(int ac, char *av[])
+{
   assert(ac == 4 && "usage: ./pnt-lut $PGM_FIFO $PNT_FIFO $OUTPUT_FIFO");
   openlog("pnt-lut", 0, LOG_USER);
 
@@ -60,24 +67,27 @@ int main(int ac, char *av[]) {
                          MAP_SHARED | MAP_ANONYMOUS, -1, 0);
   memset(global, 0, PGM_SIZE);
 
-  if (fork() == 0) {
+  if (fork() == 0)
+  {
     // parent process
     const int fd = open(pgm_fifo, O_RDONLY);
-    if (fd == -1) {
+    if (fd == -1)
+    {
       syslog(LOG_ERR, "opening fifo %s failed", pgm_fifo);
       exit(-1);
     }
     syslog(LOG_ERR, "pnt-lut: parent initialized");
 
-
-    for (;;) {
+    for (;;)
+    {
       int len_read;
       len_read = better_read(fd, global, PGM_SIZE);
       unsigned int width, height, maxval;
       sscanf((char *)global, "P5 %u %u %u", &width, &height, &maxval);
       syslog(LOG_INFO, "read PGM %d: width=%u, height=%u, maxval=%u", len_read,
              width, height, maxval);
-      if (width != PGM_W || height != PGM_H) {
+      if (width != PGM_W || height != PGM_H)
+      {
         // TODO: bail if bad? would need two arrays or to dynamically
         // read+discard sscanf or fgets could do it but it's ... not ideal
         syslog(LOG_ERR,
@@ -88,25 +98,32 @@ int main(int ac, char *av[]) {
     }
     close(fd);
     syslog(LOG_INFO, "parent: unreachable!\n");
-  } else {
+  }
+  else
+  {
     // child process
     const int fd = open(pnt_fifo, O_RDONLY);
     const int fd_out = open(output_fifo, O_WRONLY);
-    if (fd == -1) {
+    if (fd == -1)
+    {
       syslog(LOG_ERR, "opening fifo %s failed", pgm_fifo);
       exit(-1);
     }
-    if (fd_out == -1) {
+    if (fd_out == -1)
+    {
       syslog(LOG_ERR, "opening fifo %s failed", output_fifo);
       exit(-1);
     }
     syslog(LOG_ERR, "pnt-lut: child initialized");
 
     int pnt[2];
-    for (;;) {
+    for (;;)
+    {
       const int rv = better_read(fd, pnt, sizeof(pnt));
-      if (rv != sizeof(pnt)) {
-        if (rv != 0) {
+      if (rv != sizeof(pnt))
+      {
+        if (rv != 0)
+        {
           syslog(LOG_INFO, "point read failed, rv=%d\n", rv);
         }
         continue;
@@ -131,10 +148,13 @@ int main(int ac, char *av[]) {
       // offset 15
       // + row size * number of rows (y)
       // + distance into row (x)
-      if (tablet_x == 0 && tablet_y == 0) {
+      if (tablet_x == 0 && tablet_y == 0)
+      {
         // pen lifted off the tablet, disable output
         output[1] = 0;
-      } else {
+      }
+      else
+      {
         // 0-255 strength of vibration
         // cast floats to ints here to use as indexes
         output[1] = global[15 + (int)pgm_y * PGM_W + (int)pgm_x];
@@ -143,12 +163,23 @@ int main(int ac, char *av[]) {
       syslog(LOG_DEBUG, "output is 0x%x", output[1]);
 #endif
       write(fd_out, output, 2);
-      
+
       // write image to file if SIGINT is detected
-      if (sig_rcvd) {
-        const int fd1 = open("image.txt", O_WRONLY);
-        write(fd1, global, PGM_SIZE);
-        close(fd1);
+      if (sig_rcvd)
+      {
+        int pptr = open("image.pgm", O_WRONLY);
+        uint8_t pgm_buf[PGM_W][PGM_H] = {0};
+        const char *pgm_init = "P5 " STR(PGM_W) " " STR(PGM_H) " " STR(PGM_DEPTH) " ";
+        write(pptr, pgm_init, strlen(pgm_init));
+        for (unsigned jj = 0; jj < PGM_H; jj++)
+        {
+          for (unsigned ii = 0; ii < PGM_W; ii++)
+          {
+            write(pptr, &pgm_buf[ii][jj], 1);
+          }
+        }
+        syslog(LOG_INFO, "wrote PGM size %zu\n", sizeof(pgm_buf));
+        close(pptr);
         sig_rcvd = 0;
       }
     }

--- a/pnt-lut.c
+++ b/pnt-lut.c
@@ -43,7 +43,9 @@ int better_read(int fd, void *buf, int amount) {
 
 void signal_handler(int signum)
 {
+  if (signum == 2) {
     sig_rcvd = 1;
+  }
 }
 
 int main(int ac, char *av[]) {
@@ -145,7 +147,7 @@ int main(int ac, char *av[]) {
       // write image to file if SIGINT is detected
       if (sig_rcvd) {
         const int fd1 = open("image.txt", O_WRONLY);
-        write(fd1, output, 2);
+        write(fd1, global, PGM_SIZE);
         close(fd1);
         sig_rcvd = 0;
       }


### PR DESCRIPTION
Adding a signal handler function to pnt-lut.c to write the output image to a text file upon the detection of a signal (e.g. SIGINT). A flag will be set in the signal handler once a signal has been triggered and will write to a text file after checking if the flag has been set in the child process. This is based upon similar behavior seen online; I can't really test with the available hardware at my disposal so if someone can attempt to test and provide feedback that would be really helpful and I can look further into it.